### PR TITLE
to look up correct asset name, ex: [name]-[hash].js

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ module.exports = {
   },
 
   plugins: [
-    new StaticSiteGeneratorPlugin('index.js', paths, { locals... })
+    new StaticSiteGeneratorPlugin('main', paths, { locals... })
   ]
 
 };

--- a/index.js
+++ b/index.js
@@ -15,13 +15,15 @@ StaticSiteGeneratorWebpackPlugin.prototype.apply = function(compiler) {
     var renderPromises;
 
     try {
-      var asset = compiler.assets[self.renderSourcePath];
+      var assets = getAssetsFromCompiler(compiler);
+
+      var filename = assets[self.renderSourcePath] || self.renderSourcePath;
+
+      var asset = compiler.assets[filename];
 
       if (asset === undefined) {
         throw new Error('Source file not found: "' + self.renderSourcePath + '"');
       }
-
-      var assets = getAssetsFromCompiler(compiler);
 
       var source = asset.source();
       var render = evaluate(source, /* filename: */ undefined, /* scope: */ undefined, /* includeGlobals: */ true);


### PR DESCRIPTION
I added this to lookup the correct filename when using `[name]-[hash].js` in webpackConfig.output.filename .

"index.js" and "main" both should work, but using "main" works fine when the filename pattern is `[name]-[hash].js` 

    new StaticSiteGeneratorPlugin('index.js', paths, { locals... })
    new StaticSiteGeneratorPlugin('main', paths, { locals... })