### PR TITLE
Expose webpack stats to the rendering function

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,8 @@ StaticSiteGeneratorWebpackPlugin.prototype.apply = function(compiler) {
   compiler.plugin('emit', function(compiler, done) {
     var renderPromises;
 
-    var webpackStatsJson = compiler.getStats().toJson();
+    var webpackStats = compiler.getStats();
+    var webpackStatsJson = webpackStats.toJson();
 
     try {
       var asset = findAsset(self.renderSrc, compiler, webpackStatsJson);
@@ -34,7 +35,8 @@ StaticSiteGeneratorWebpackPlugin.prototype.apply = function(compiler) {
 
         var locals = {
           path: outputPath,
-          assets: assets
+          assets: assets,
+          webpackStats: webpackStats
         };
 
         for (var prop in self.locals) {


### PR DESCRIPTION
The `ExtractText` webpack plugin reuses the chunk name, and this plugin only takes the first chunk of any given asset. So it's impossible to refer to the extracted and fingerprinted CSS file. Expose the full webpack stats object to the rendering function so it can read out any information necessary to generate the HTML file.