### PR TITLE
Include stack traces and bundle filename in errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ StaticSiteGeneratorWebpackPlugin.prototype.apply = function(compiler) {
       var assets = getAssetsFromCompiler(compiler, webpackStatsJson);
 
       var source = asset.source();
-      var render = evaluate(source, /* filename: */ undefined, /* scope: */ undefined, /* includeGlobals: */ true);
+      var render = evaluate(source, /* filename: */ self.renderSrc, /* scope: */ undefined, /* includeGlobals: */ true);
 
       renderPromises = self.outputPaths.map(function(outputPath) {
         var outputFileName = path.join(outputPath, '/index.html')
@@ -49,13 +49,13 @@ StaticSiteGeneratorWebpackPlugin.prototype.apply = function(compiler) {
             compiler.assets[outputFileName] = createAssetFromContents(output);
           })
           .catch(function(err) {
-            compiler.errors.push(err);
+            compiler.errors.push(err.stack);
           });
       });
 
       Promise.all(renderPromises).nodeify(done);
     } catch (err) {
-      compiler.errors.push(err);
+      compiler.errors.push(err.stack);
       done(err);
     }
   });


### PR DESCRIPTION
I think it is better to include stack traces and bundle file names in error reports. You can at least see which function the error was thrown in or if it was at the top level.

With patch:
```
ERROR in ReferenceError: bar is not defined
    at foo (bundle.js:70:6)
    at render (bundle.js:111:6)
    at tryCatcher (/Users/zenlambda/blog/node_modules/static-site-generator-webpack-plugin/node_modules/bluebird/js/main/util.js:26:23)
    at Function.Promise.fromNode (/Users/zenlambda/blog/node_modules/static-site-generator-webpack-plugin/node_modules/bluebird/js/main/promise.js:165:30)
    at /Users/zenlambda/blog/node_modules/static-site-generator-webpack-plugin/index.js:47:12
    at Array.map (native)
    at Compiler.<anonymous> (/Users/zenlambda/blog/node_modules/static-site-generator-webpack-plugin/index.js:31:41)
    at Compiler.applyPluginsAsync (/Users/zenlambda/blog/node_modules/webpack/node_modules/tapable/lib/Tapable.js:71:13)
    at Compiler.emitAssets (/Users/zenlambda/blog/node_modules/webpack/lib/Compiler.js:226:7)
    at Watching.<anonymous> (/Users/zenlambda/blog/node_modules/webpack/lib/Compiler.js:54:18)
```

Without patch:
```
ERROR in ReferenceError: bar is not defined
```