### PR TITLE
Support non index.html files

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ StaticSiteGeneratorWebpackPlugin.prototype.apply = function(compiler) {
       var render = evaluate(source, /* filename: */ self.renderSrc, /* scope: */ undefined, /* includeGlobals: */ true);
 
       renderPromises = self.outputPaths.map(function(outputPath) {
-        var outputFileName = path.join(outputPath, '/index.html')
+        var outputFileName = (path.extname(outputPath) === '.html') ? outputPath : path.join(outputPath, '/index.html')
           .replace(/^(\/|\\)/, ''); // Remove leading slashes for webpack-dev-server
 
         var locals = {


### PR DESCRIPTION
- fix: https://github.com/markdalgleish/static-site-generator-webpack-plugin/issues/9
- fix: https://github.com/gatsbyjs/gatsby/issues/14