### PR TITLE
Add support for generating paths that contains `.html`

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,8 +38,11 @@ StaticSiteGeneratorWebpackPlugin.prototype.apply = function(compiler) {
       }
 
       renderPromises = self.outputPaths.map(function(outputPath) {
-        var outputFileName = path.join(outputPath, '/index.html')
-          .replace(/^(\/|\\)/, ''); // Remove leading slashes for webpack-dev-server
+        var outputFileName = outputPath.replace(/^(\/|\\)/, ''); // Remove leading slashes for webpack-dev-server
+
+        if (!/\.(html?)$/i.test(outputFileName)) {
+            outputFileName = path.join(outputFileName, '/index.html');
+        }
 
         var locals = {
           path: outputPath,


### PR DESCRIPTION
I have the same use case as described in #9, and this commit fixes that.

I don't see any reason for why this shouldn't be configurable. :)