### PR TITLE
Fix root index.html path for dev server

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ StaticSiteGeneratorWebpackPlugin.prototype.apply = function(compiler) {
         var outputFileName = outputPath.replace(/^(\/|\\)/, ''); // Remove leading slashes for webpack-dev-server
 
         if (!/\.(html?)$/i.test(outputFileName)) {
-            outputFileName = path.join(outputFileName, '/index.html');
+            outputFileName = path.join(outputFileName, 'index.html');
         }
 
         var locals = {


### PR DESCRIPTION
Before a path of `/` would result in an asset named `/index.html` which can't be served by webpack-dev-server. `path.join` already adds the necessary `/` if outputFilename isn't empty.

Related: #18