### PR TITLE
require.ensure support

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ StaticSiteGeneratorWebpackPlugin.prototype.apply = function(compiler) {
       var assets = getAssetsFromCompiler(compiler, webpackStatsJson);
 
       var source = asset.source();
-      var render = evaluate(source, /* filename: */ self.renderSrc, /* scope: */ undefined, /* includeGlobals: */ true);
+      var render = evaluate(source, /* filename: */ self.renderSrc, /* scope: */ {window: {}}, /* includeGlobals: */ true);
 
       if ('__esModule' in render) {
         render = render['default'];

--- a/test/success-cases/require-ensure/expected-output/1.index.js
+++ b/test/success-cases/require-ensure/expected-output/1.index.js
@@ -1,0 +1,10 @@
+webpackJsonp([1],[
+/* 0 */,
+/* 1 */
+/***/ function(module, exports) {
+
+	module.exports = 'Foo';
+
+
+/***/ }
+]);

--- a/test/success-cases/require-ensure/expected-output/foo/bar/index.html
+++ b/test/success-cases/require-ensure/expected-output/foo/bar/index.html
@@ -1,0 +1,5 @@
+<html>
+  <body>
+    <h1>/foo/bar</h1>
+  </body>
+</html>

--- a/test/success-cases/require-ensure/expected-output/foo/index.html
+++ b/test/success-cases/require-ensure/expected-output/foo/index.html
@@ -1,0 +1,5 @@
+<html>
+  <body>
+    <h1>/foo</h1>
+  </body>
+</html>

--- a/test/success-cases/require-ensure/expected-output/index.html
+++ b/test/success-cases/require-ensure/expected-output/index.html
@@ -1,0 +1,5 @@
+<html>
+  <body>
+    <h1>/</h1>
+  </body>
+</html>

--- a/test/success-cases/require-ensure/foo.js
+++ b/test/success-cases/require-ensure/foo.js
@@ -1,0 +1,1 @@
+module.exports = 'Foo';

--- a/test/success-cases/require-ensure/index.js
+++ b/test/success-cases/require-ensure/index.js
@@ -1,0 +1,13 @@
+// Do not actually call this function, because executing require.ensure requires a 'document'.
+function dontDoIt() {
+  require.ensure([], function() {
+    var foo = require('./foo');  
+  });    
+}
+
+module.exports = function(locals, callback) {
+  setTimeout(function() {
+    callback(null, locals.template({ html: '<h1>' + locals.path + '</h1>' }));
+  }, 10);
+
+};

--- a/test/success-cases/require-ensure/template.ejs
+++ b/test/success-cases/require-ensure/template.ejs
@@ -1,0 +1,5 @@
+<html>
+  <body>
+    <%- html %>
+  </body>
+</html>

--- a/test/success-cases/require-ensure/webpack.config.js
+++ b/test/success-cases/require-ensure/webpack.config.js
@@ -1,0 +1,28 @@
+var StaticSiteGeneratorPlugin = require('../../../');
+var ejs = require('ejs');
+var fs = require('fs');
+
+var template = ejs.compile(fs.readFileSync(__dirname + '/template.ejs', 'utf-8'))
+
+var paths = [
+  '/',
+  '/foo',
+  '/foo/bar'
+];
+
+module.exports = {
+  entry: {
+    main: __dirname + '/index.js'
+  },
+
+  output: {
+    filename: 'index.js',
+    path: __dirname + '/actual-output',
+    publicPath: '/',
+    libraryTarget: 'umd'
+  },
+
+  plugins: [
+    new StaticSiteGeneratorPlugin('main', paths, { template: template })
+  ]
+};


### PR DESCRIPTION
This adds support for webpack's `require.ensure` which enables [code splitting and async chunk loading](https://webpack.github.io/docs/code-splitting.html).

When the script (not the `require.ensure` itself) is evaluated, webpack expects a `window` object; this is solved by supplying an empty object to `node-eval`'s scope.

Note that it's not possible to _use_ `require.ensure` during the static build (because it expects a DOM) but it's now possible to do code splitting with React Router like it's described in Ryan Florence's [Welcome to the Future of Web Application Delivery](https://medium.com/@ryanflorence/welcome-to-future-of-web-application-delivery-9750b7564d9f) or in something like `componentDidMount`. For example:

```js

class MyLazyComponent extends React.Component {
  componentDidMount() {
    require.ensure([], function() {
      // the 'foo' module is split into a separate JS chunk and only loaded when this component is mounted
      var foo = require('foo');
      // use foo
    })
  }
  render() {
    return <div></div>;
  }
}
```

Potentially breaking if someone checks for `window` to do the client side render instead of `document`.