### PR TITLE
allow renderSrc to be specified as an array

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,16 +18,25 @@ StaticSiteGeneratorWebpackPlugin.prototype.apply = function(compiler) {
     var webpackStatsJson = webpackStats.toJson();
 
     try {
-      var asset = findAsset(self.renderSrc, compiler, webpackStatsJson);
+      var source = '';
+      var renderSources =
+        Array.isArray(self.renderSrc) ? self.renderSrc : [self.renderSrc];
+      renderSources.forEach(function (renderSource) {
+        var asset = findAsset(renderSource, compiler, webpackStatsJson);
 
-      if (asset == null) {
-        throw new Error('Source file not found: "' + self.renderSrc + '"');
-      }
+        if (asset == null) {
+          throw new Error('Source file not found: "' + renderSource + '"');
+        }
+
+        source = source + '\n' + asset.source();
+      });
 
       var assets = getAssetsFromCompiler(compiler, webpackStatsJson);
-
-      var source = asset.source();
-      var render = evaluate(source, /* filename: */ self.renderSrc, /* scope: */ undefined, /* includeGlobals: */ true);
+      var render = evaluate(
+        source,
+        /* filename: */ renderSources[renderSources.length - 1],
+        /* scope: */ undefined,
+        /* includeGlobals: */ true);
 
       if (render.hasOwnProperty('__esModule')) {
         render = render['default'];


### PR DESCRIPTION
- For when webpack bundle is output as multiple chunk files
- Simply concatenates the file sources - probably should find a way to evaluate them one after another