### PR TITLE
add window mock to allow dynamic code includes

### DIFF
--- a/test/success-cases/require-ensure/webpack.config.js
+++ b/test/success-cases/require-ensure/webpack.config.js
@@ -23,6 +23,6 @@ module.exports = {
   },
 
   plugins: [
-    new StaticSiteGeneratorPlugin('main', paths, { template: template }, { window: {} })
+    new StaticSiteGeneratorPlugin('main', paths, { template: template }, { }, true)
   ]
 };


### PR DESCRIPTION
Hello.

I 'm using static site generator plugin, react-router and dynamic code includes.
It occurred that I have to mock two or three functions of window and document object to make dynamic code inclusion work. 
`createElement` is used once to create 'script' element tag with 'src' property which holds script name that should be loaded
`getElementsByTagName` is used once to get 'head' tag, which should have only one member
`appendChild` which is used, again, only once to add a `script` tag to head.

I use 'src' property of a `script` tag to get the required name and then get it from assets in webpack.
May be, it would be better to add common `require` function if `findAsset` fails

To add this 'mock' simply add fifth parameter for StaticSiteGeneratorPlugin, which should be 'true'
Hope this helps anyone 