### PR TITLE
Handle commonschunkplugin assets

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,10 +27,12 @@ StaticSiteGeneratorWebpackPlugin.prototype.apply = function(compiler) {
           throw new Error('Source file not found: "' + self.renderSrc + '"');
         }
 
+        var scope = loadChunkAssetsToScope(self.scope, compilation, webpackStatsJson);
+
         var assets = getAssetsFromCompilation(compilation, webpackStatsJson);
 
         var source = asset.source();
-        var render = evaluate(source, /* filename: */ self.renderSrc, /* scope: */ self.scope, /* includeGlobals: */ true);
+        var render = evaluate(source, /* filename: */ self.renderSrc, /* scope: */ scope, /* includeGlobals: */ true);
 
         if (render.hasOwnProperty('default')) {
           render = render['default'];
@@ -80,6 +82,41 @@ StaticSiteGeneratorWebpackPlugin.prototype.apply = function(compiler) {
     });
   });
 };
+
+function merge (a, b) {
+  if (!a || !b) return a
+  var keys = Object.keys(b)
+  for (var k, i = 0, n = keys.length; i < n; i++) {
+    k = keys[i]
+    a[k] = b[k]
+  }
+  return a
+}
+
+var loadChunkAssetsToScope = function(scope, compilation, webpackStatsJson) {
+  var manifest = findAsset('manifest', compilation, webpackStatsJson);
+  var vendor = findAsset('vendor', compilation, webpackStatsJson);
+
+  if (!manifest || !vendor) {
+    return scope;
+  }
+
+  //var manifestRender = evaluate(manifest.source(), 'manifest', self.scope, true);
+  if (!scope.window) {
+    scope.window = {};
+  }
+
+  var sandbox = {};
+
+  merge(sandbox, scope);
+  var manifestScript = new vm.Script(manifest.source());
+  var manifestRender = manifestScript.runInNewContext(sandbox, {});
+
+  var vendorScript = new vm.Script(vendor.source());
+  var vendorRender = vendorScript.runInNewContext(sandbox.window, {});
+
+  return sandbox.window;
+}
 
 var findAsset = function(src, compilation, webpackStatsJson) {
   var asset = compilation.assets[src];


### PR DESCRIPTION
Currently, commonschunkplugin will pull vendor libraries into a separate asset and use a manifest file to pull assets on demand. Webpack does this by updating the main app asset to use a global webpackJsonp function to pull in dependencies. WebpackJsonp will not be available in the global context during eval and the build will fail.

I've added a function the does an eval on both manifest and vendor assets, then inserts those into the scope of the main app eval. This should make any vendor related assets available to the app during build time. 