### PR TITLE
Better error message when forgetting to add UMD in targetLib

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ StaticSiteGeneratorWebpackPlugin.prototype.apply = function(compiler) {
         }
 
         if (typeof render !== 'function') {
-          throw new Error('Export from "' + self.renderSrc + '" must be a function that returns an HTML string');
+          throw new Error('Export from "' + self.renderSrc + '" must be a function that returns an HTML string. Is output.targetLib in the configuration set to "umd"?');
         }
 
         renderPromises = self.outputPaths.map(function(outputPath) {


### PR DESCRIPTION
When you forget to set "targetLib" in the configuration file, you'll get the following error:
"Export from "'main" must be a function that returns an HTML string" .

That's very misleading for the most common use case.
This pull request adds a suggested fix to the error message.