### PR TITLE
Fix a bug occuring when outputPaths is undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var Promise = require('bluebird');
 
 function StaticSiteGeneratorWebpackPlugin(renderSrc, outputPaths, locals, scope) {
   this.renderSrc = renderSrc;
-  this.outputPaths = Array.isArray(outputPaths) ? outputPaths : [outputPaths];
+  this.outputPaths = Array.isArray(outputPaths) ? outputPaths : [ outputPaths || renderSrc + '.html' ];
   this.locals = locals;
   this.scope = scope;
 }


### PR DESCRIPTION
When *outputPaths* is `undefined`, *outputPaths* is happened to an `array` resulting in an error at 44:42

> Cannot read property 'replace' of undefined

I chosed to use the bundle name with html extension as default path.

Empty string will be considered as undefined. I could have done:

```
this.outputPaths = Array.isArray(outputPaths) ? outputPaths : ['string' === typeof outputPaths ? outputPaths : renderSrc + '.html']
```

but it seemed unjustified.