### PR TITLE
Add basename support for crawl mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,24 @@ module.exports = {
 };
 ```
 
+If your app uses `basename` in React Router or other routers with similar
+behavior to prefix links and routes with a url segment, you can include a
+`basename` option and the crawler will account for it when evaluating links:
+
+```js
+module.exports = {
+
+  ...
+
+  plugins: [
+    new StaticSiteGeneratorPlugin({
+      crawl: true,
+      basename: '/your-project-name/docs'
+    })
+  ]
+};
+```
+
 ## Custom file names
 
 By providing paths that end in `.html`, you can generate custom file names other than the default `index.html`. Please note that this may break compatibility with your router, if you're using one.

--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ function StaticSiteGeneratorWebpackPlugin(options) {
   this.locals = options.locals;
   this.globals = options.globals;
   this.crawl = Boolean(options.crawl);
+  this.basename = options.basename;
 }
 
 StaticSiteGeneratorWebpackPlugin.prototype.apply = function(compiler) {
@@ -49,7 +50,7 @@ StaticSiteGeneratorWebpackPlugin.prototype.apply = function(compiler) {
           throw new Error('Export from "' + self.entry + '" must be a function that returns an HTML string. Is output.libraryTarget in the configuration set to "umd"?');
         }
 
-        renderPaths(self.crawl, self.locals, self.paths, render, assets, webpackStats, compilation)
+        renderPaths(self.crawl, self.basename, self.locals, self.paths, render, assets, webpackStats, compilation)
           .nodeify(done);
       } catch (err) {
         compilation.errors.push(err.stack);
@@ -59,7 +60,7 @@ StaticSiteGeneratorWebpackPlugin.prototype.apply = function(compiler) {
   });
 };
 
-function renderPaths(crawl, userLocals, paths, render, assets, webpackStats, compilation) {
+function renderPaths(crawl, basename, userLocals, paths, render, assets, webpackStats, compilation) {
   var renderPromises = paths.map(function(outputPath) {
     var locals = {
       path: outputPath,
@@ -94,10 +95,11 @@ function renderPaths(crawl, userLocals, paths, render, assets, webpackStats, com
           if (crawl) {
             var relativePaths = relativePathsFromHtml({
               source: rawSource,
-              path: key
+              path: key,
+              basename: basename
             });
 
-            return renderPaths(crawl, userLocals, relativePaths, render, assets, webpackStats, compilation);
+            return renderPaths(crawl, basename, userLocals, relativePaths, render, assets, webpackStats, compilation);
           }
         });
 
@@ -206,9 +208,15 @@ function relativePathsFromHtml(options) {
         return null;
       }
 
-      return parsed.path.indexOf('/') === 0 ?
+      var path = parsed.path.indexOf('/') === 0 ?
         parsed.path :
         url.resolve(currentPath, parsed.path);
+
+      if (path.indexOf(options.basename) === 0) {
+        return path.replace(options.basename, '');
+      }
+
+      return path;
     })
     .filter(function(href) {
       return href != null;


### PR DESCRIPTION
👋 

I tried out the new crawl mode today, and it's awesome!

My app uses `basename` with React Router to handle deployment to GitHub pages, so my routes look like `/about`, but the deployed URLs look like `username.github.io/project-name/docs/about`. This broke the crawler, understandably. It generated the pages but put all of them after the index in a nested subdirectory that matched the basename.

This change lets you pass in a basename so that the crawler will disregard it, and all of the pages get built correctly. If you're interested in something like this let me know and I can add some tests.