### PR TITLE
Handle CommonsChunkPlugin Assets (updated)

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,6 @@ StaticSiteGeneratorWebpackPlugin.prototype.apply = function(compiler) {
 
         var source = asset.source();
         var render = evaluate(source, /* filename: */ self.renderSrc, /* scope: */ scope, /* includeGlobals: */ true);
-
         if (render.hasOwnProperty('default')) {
           render = render['default'];
         }
@@ -134,6 +133,10 @@ var loadChunkAssetsToScope = function(scope, compilation, webpackStatsJson) {
 
   if (!manifest || !vendor) {
     return scope;
+  }
+
+  if(!scope) {
+    scope = {};
   }
 
   if (!scope.window) {

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var path = require('path');
 var cheerio = require('cheerio');
 var url = require('url');
 var Promise = require('bluebird');
+var vm = require('vm');
 
 function StaticSiteGeneratorWebpackPlugin(options) {
   if (arguments.length > 1) {

--- a/index.js
+++ b/index.js
@@ -124,6 +124,10 @@ function merge (a, b) {
   return a
 }
 
+/*
+ * Function to handle commonschunk plugin. Currently only supports a manifest file and single external
+ * library file name vendor.
+ */
 var loadChunkAssetsToScope = function(scope, compilation, webpackStatsJson) {
   var manifest = findAsset('manifest', compilation, webpackStatsJson);
   var vendor = findAsset('vendor', compilation, webpackStatsJson);
@@ -132,19 +136,20 @@ var loadChunkAssetsToScope = function(scope, compilation, webpackStatsJson) {
     return scope;
   }
 
-  //var manifestRender = evaluate(manifest.source(), 'manifest', self.scope, true);
   if (!scope.window) {
     scope.window = {};
   }
 
   var sandbox = {};
-
   merge(sandbox, scope);
+
   var manifestScript = new vm.Script(manifest.source());
-  var manifestRender = manifestScript.runInNewContext(sandbox, {});
+  manifestScript.runInNewContext(sandbox, {});
+
+  merge(sandbox, sandbox.window)
 
   var vendorScript = new vm.Script(vendor.source());
-  var vendorRender = vendorScript.runInNewContext(sandbox.window, {});
+  vendorScript.runInNewContext(sandbox, {});
 
   return sandbox.window;
 }

--- a/index.js
+++ b/index.js
@@ -36,10 +36,12 @@ StaticSiteGeneratorWebpackPlugin.prototype.apply = function(compiler) {
           throw new Error('Source file not found: "' + self.entry + '"');
         }
 
+        var scope = loadChunkAssetsToScope(self.scope, compilation, webpackStatsJson);
+
         var assets = getAssetsFromCompilation(compilation, webpackStatsJson);
 
         var source = asset.source();
-        var render = evaluate(source, /* filename: */ self.entry, /* scope: */ self.globals, /* includeGlobals: */ true);
+        var render = evaluate(source, /* filename: */ self.renderSrc, /* scope: */ scope, /* includeGlobals: */ true);
 
         if (render.hasOwnProperty('default')) {
           render = render['default'];
@@ -109,6 +111,41 @@ function renderPaths(crawl, userLocals, paths, render, assets, webpackStats, com
   });
 
   return Promise.all(renderPromises);
+}
+
+function merge (a, b) {
+  if (!a || !b) return a
+  var keys = Object.keys(b)
+  for (var k, i = 0, n = keys.length; i < n; i++) {
+    k = keys[i]
+    a[k] = b[k]
+  }
+  return a
+}
+
+var loadChunkAssetsToScope = function(scope, compilation, webpackStatsJson) {
+  var manifest = findAsset('manifest', compilation, webpackStatsJson);
+  var vendor = findAsset('vendor', compilation, webpackStatsJson);
+
+  if (!manifest || !vendor) {
+    return scope;
+  }
+
+  //var manifestRender = evaluate(manifest.source(), 'manifest', self.scope, true);
+  if (!scope.window) {
+    scope.window = {};
+  }
+
+  var sandbox = {};
+
+  merge(sandbox, scope);
+  var manifestScript = new vm.Script(manifest.source());
+  var manifestRender = manifestScript.runInNewContext(sandbox, {});
+
+  var vendorScript = new vm.Script(vendor.source());
+  var vendorRender = vendorScript.runInNewContext(sandbox.window, {});
+
+  return sandbox.window;
 }
 
 var findAsset = function(src, compilation, webpackStatsJson) {

--- a/test/success-cases/commonschunk/expected-output/foo/bar/index.html
+++ b/test/success-cases/commonschunk/expected-output/foo/bar/index.html
@@ -1,0 +1,5 @@
+<html>
+  <body>
+    <h1>/foo/bar</h1>
+  </body>
+</html>

--- a/test/success-cases/commonschunk/expected-output/foo/index.html
+++ b/test/success-cases/commonschunk/expected-output/foo/index.html
@@ -1,0 +1,5 @@
+<html>
+  <body>
+    <h1>/foo</h1>
+  </body>
+</html>

--- a/test/success-cases/commonschunk/expected-output/index.html
+++ b/test/success-cases/commonschunk/expected-output/index.html
@@ -1,0 +1,5 @@
+<html>
+  <body>
+    <h1>/</h1>
+  </body>
+</html>

--- a/test/success-cases/commonschunk/index.js
+++ b/test/success-cases/commonschunk/index.js
@@ -1,0 +1,5 @@
+module.exports = function(locals, callback) {
+  setTimeout(function() {
+    callback(null, locals.template({ html: '<h1>' + locals.path + '</h1>' }));
+  }, 10);
+};

--- a/test/success-cases/commonschunk/template.ejs
+++ b/test/success-cases/commonschunk/template.ejs
@@ -1,0 +1,5 @@
+<html>
+  <body>
+    <%- html %>
+  </body>
+</html>

--- a/test/success-cases/commonschunk/webpack.config.js
+++ b/test/success-cases/commonschunk/webpack.config.js
@@ -29,7 +29,13 @@ module.exports = {
       names: ['vendor', 'manifest'],
       minChunks: Infinity
     }),
-    new StaticSiteGeneratorPlugin('index.js', paths, { template: template }),
+    new StaticSiteGeneratorPlugin({
+      entry: 'index',
+      paths: paths,
+      locals: {
+        template: template
+      }
+    }),
     new StatsWriterPlugin() // Causes the asset's `size` method to be called
   ]
 };

--- a/test/success-cases/commonschunk/webpack.config.js
+++ b/test/success-cases/commonschunk/webpack.config.js
@@ -1,0 +1,35 @@
+var StaticSiteGeneratorPlugin = require('../../../');
+var StatsWriterPlugin = require("webpack-stats-plugin").StatsWriterPlugin;
+var webpack = require('webpack');
+var ejs = require('ejs');
+var fs = require('fs');
+
+var template = ejs.compile(fs.readFileSync(__dirname + '/template.ejs', 'utf-8'))
+
+var paths = [
+  '/',
+  '/foo',
+  '/foo/bar'
+];
+
+module.exports = {
+  entry: {
+    index: __dirname + '/index.js',
+    vendor: 'bluebird'
+  },
+
+  output: {
+    filename: '[name].js',
+    path: __dirname + '/actual-output',
+    libraryTarget: 'umd'
+  },
+
+  plugins: [
+    new webpack.optimize.CommonsChunkPlugin({
+      names: ['vendor', 'manifest'],
+      minChunks: Infinity
+    }),
+    new StaticSiteGeneratorPlugin('index.js', paths, { template: template }),
+    new StatsWriterPlugin() // Causes the asset's `size` method to be called
+  ]
+};


### PR DESCRIPTION
Building on @stephen-haddix's work, I've rebased his branch against `master`, bringing it up to date. I also updated his test to use the new configuration format, but I did run it using the legacy arguments format, and it worked the same.

The biggest change here is the removal of hard-coded chunk names. From https://webpack.js.org/guides/caching/#deterministic-hashes:

> Separate your vendor and application code with CommonsChunkPlugin and create an explicit vendor chunk to prevent it from changing too often. When CommonsChunkPlugin is used, the runtime code is moved to the **last common entry**. 

(Emphasis added)

Knowing this, we can now handle an arbitrary number of chunks, because we know the `webpackJsonP` function is loaded into the last chunk. Just like in the browser, this last chunk needs to be executed first, so that it can load the necessary chunks and functions for the subsequent chunks to execute properly.

Happy to explain it in more detail if required. Let me know if there are any updates you'd like made.