### PR TITLE
Add transform function

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,14 +101,34 @@ Note that this will still be executed for each entry in your `paths` array in yo
 // The path currently being rendered:
 locals.path;
 
-// An object containing all assets:
-locals.assets;
-
 // Advanced: Webpack's stats object:
 locals.webpackStats;
 ```
 
-Any additional locals provided in your config are also available.
+## Custom locals
+
+To customise the locals provided to your render function you can use the `locals` option.
+A function passed to this option will be called before each render.
+The result will be used when rendering.
+
+```js
+const template = ejs.compile(templateSource);
+
+module.exports = {
+
+  ...
+
+  plugins: [
+    new StaticSiteGeneratorPlugin({
+      locals: ({ path, webpackStats }) => {
+        template,
+        path,
+        webpackStats
+      }
+    })
+  ]
+}
+```
 
 ## Crawl mode
 

--- a/index.js
+++ b/index.js
@@ -132,7 +132,9 @@ var findAsset = function(src, compilation, webpackStatsJson) {
   // Webpack outputs an array for each chunk when using sourcemaps
   if (chunkValue instanceof Array) {
     // Is the main bundle always the first element?
-    chunkValue = chunkValue[0];
+    chunkValue = chunkValue.find(function(filename) {
+      return /\.js$/.test(filename);
+    });
   }
   return compilation.assets[chunkValue];
 };
@@ -145,8 +147,10 @@ var getAssetsFromCompilation = function(compilation, webpackStatsJson) {
 
     // Webpack outputs an array for each chunk when using sourcemaps
     if (chunkValue instanceof Array) {
-      // Is the main bundle always the first element?
-      chunkValue = chunkValue[0];
+      // Is the main bundle always the first JS element?
+      chunkValue = chunkValue.find(function(filename) {
+        return /\.js$/.test(filename);
+      });
     }
 
     if (compilation.options.output.publicPath) {

--- a/index.js
+++ b/index.js
@@ -22,8 +22,8 @@ function StaticSiteGeneratorWebpackPlugin(options) {
 StaticSiteGeneratorWebpackPlugin.prototype.apply = function(compiler) {
   var self = this;
 
-  compiler.plugin('this-compilation', function(compilation) {
-    compilation.plugin('optimize-assets', function(_, done) {
+  addThisCompilationHandler(compiler, function(compilation) {
+    addOptimizeAssetsHandler(compilation, function(_, done) {
       var renderPromises;
 
       var webpackStats = compilation.getStats();
@@ -222,6 +222,24 @@ function legacyArgsToOptions(entry, paths, locals, globals) {
     locals: locals,
     globals: globals
   };
+}
+
+function addThisCompilationHandler(compiler, callback) {
+  if(compiler.hooks) {
+    /* istanbul ignore next */
+    compiler.hooks.thisCompilation.tap('static-site-generator-webpack-plugin', callback);
+  } else {
+    compiler.plugin('this-compilation', callback);
+  }
+}
+
+function addOptimizeAssetsHandler(compilation, callback) {
+  if(compilation.hooks) {
+    /* istanbul ignore next */
+    compilation.hooks.optimizeAssets.tapAsync('static-site-generator-webpack-plugin',callback);
+  } else {
+    compilation.plugin('optimize-assets', callback);
+  }
 }
 
 module.exports = StaticSiteGeneratorWebpackPlugin;

--- a/test/__snapshots__/index.spec.js.snap
+++ b/test/__snapshots__/index.spec.js.snap
@@ -436,3 +436,11 @@ Object {
   "index.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
 }
 `;
+
+exports[`Success cases transform-locals should generate the expected files 1`] = `
+Object {
+  "bar.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
+  "index.html": "<div>/foo/bar.js<br />/foo/main.js</div>",
+  "main.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
+}
+`;

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -6,7 +6,7 @@ const webpack = promisify(require('webpack'));
 const rimrafAsync = promisify(require('rimraf'));
 const getSubDirsSync = require('./utils/get-sub-dirs-sync');
 const dirContentsToObject = require('./utils/dir-contents-to-object');
-const directoryContains = require('./utils/directory-contains');
+const directoryContains = require('./utils/directory-contains-html');
 
 const successCases = getSubDirsSync(__dirname + '/success-cases');
 const errorCases = getSubDirsSync(__dirname + '/error-cases');

--- a/test/success-cases/transform-locals/bar.js
+++ b/test/success-cases/transform-locals/bar.js
@@ -1,0 +1,1 @@
+module.exports = 'Foo';

--- a/test/success-cases/transform-locals/index.js
+++ b/test/success-cases/transform-locals/index.js
@@ -1,0 +1,3 @@
+module.exports = function(locals) {
+  return '<div>' + locals.chunks.join('<br />') + '</div>';
+};

--- a/test/success-cases/transform-locals/webpack.config.js
+++ b/test/success-cases/transform-locals/webpack.config.js
@@ -1,0 +1,30 @@
+var StaticSiteGeneratorPlugin = require('../../../');
+var ejs = require('ejs');
+var fs = require('fs');
+
+var paths = ['/', '/foo', '/foo/bar'];
+
+module.exports = {
+  entry: {
+    bar: __dirname + '/bar.js',
+    main: __dirname + '/index.js'
+  },
+
+  output: {
+    filename: '[name].js',
+    path: __dirname + '/actual-output',
+    publicPath: '/foo/',
+    libraryTarget: 'umd'
+  },
+
+  plugins: [
+    new StaticSiteGeneratorPlugin({
+      entry: 'main',
+      locals: ({ path, webpackStats }) => ({
+        chunks: Object.keys(webpackStats.compilation.assets).map(
+          file => `${webpackStats.compilation.outputOptions.publicPath}${file}`
+        )
+      })
+    })
+  ]
+};

--- a/test/utils/directory-contains-html.js
+++ b/test/utils/directory-contains-html.js
@@ -21,7 +21,7 @@ module.exports = function(referenceDir, targetDir, done) {
     });
   };
 
-  glob('**/*', { cwd: referenceDir, nodir: true }, function(err, files) {
+  glob('**/*.html', { cwd: referenceDir, nodir: true }, function(err, files) {
     if (err) {
       return done(err);
     }


### PR DESCRIPTION
This change is an attempt to address the below issue. Depending on any feedback on this issue this change may not be needed.

closes: https://github.com/markdalgleish/static-site-generator-webpack-plugin/issues/121

# Transform function
Adds a transform function that allows locals to be transformed into the variables expected by render function.
Transform function runs per render path.

Example usage:
```js
const entries
new StaticSiteGeneratorPlugin({
  transformLocals: (locals) => {
  const mainChunkAssets = locals.webpackStats.assetsByChunkName.main
    .map(value => `${publicPath}${value}`);

  const clientJsEntries = mainChunkAssets
    .filter(value => value.match(/\.js/))

  const clientCssEntries = mainChunkAssets
    .filter(value => value.match(/\.css$/))

    return { ...locals, clientJsEntries, clientCssEntries}
  }
})
```