### PR TITLE
Select JS chunk with some extra logic, fixes a bug with webpack 4 + mini-css-extract-plugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -132,7 +132,9 @@ var findAsset = function(src, compilation, webpackStatsJson) {
   // Webpack outputs an array for each chunk when using sourcemaps
   if (chunkValue instanceof Array) {
     // Is the main bundle always the first element?
-    chunkValue = chunkValue[0];
+    chunkValue = chunkValue.find(function(filename) {
+      return /\.js$/.test(filename);
+    });
   }
   return compilation.assets[chunkValue];
 };

--- a/index.js
+++ b/index.js
@@ -145,8 +145,10 @@ var getAssetsFromCompilation = function(compilation, webpackStatsJson) {
 
     // Webpack outputs an array for each chunk when using sourcemaps
     if (chunkValue instanceof Array) {
-      // Is the main bundle always the first element?
-      chunkValue = chunkValue[0];
+      // Is the main bundle always the first JS element?
+      chunkValue = chunkValue.find(function(filename) {
+        return /\.js$/.test(filename);
+      });
     }
 
     if (compilation.options.output.publicPath) {

--- a/test/success-cases/legacy-args/expected-output/1.index.js
+++ b/test/success-cases/legacy-args/expected-output/1.index.js
@@ -1,10 +1,10 @@
 webpackJsonp([1],[
 /* 0 */,
 /* 1 */
-/***/ function(module, exports) {
+/***/ (function(module, exports) {
 
 	module.exports = 'Foo';
 
 
-/***/ }
+/***/ })
 ]);

--- a/test/success-cases/require-ensure/expected-output/1.index.js
+++ b/test/success-cases/require-ensure/expected-output/1.index.js
@@ -1,10 +1,10 @@
 webpackJsonp([1],[
 /* 0 */,
 /* 1 */
-/***/ function(module, exports) {
+/***/ (function(module, exports) {
 
 	module.exports = 'Foo';
 
 
-/***/ }
+/***/ })
 ]);


### PR DESCRIPTION
For our internal projects, this fixed #123. The problem, as listed in the issue (thanks @richsilv), was that static-site-generator-webpack-plugin assumed that when multiple assets were present for a chunk, the first chunk would be the JS chunk.

This assumption has been replaced with a simple Array.find() to find the first /\.js$/ match instead.

For those waiting for this to be merged, you can temporarily just refer to a fixed commit instead:

```bash
yarn add --dev static-site-generator-webpack-plugin@medialaan/static-site-generator-webpack-plugin#58524c0

# or

npm install --save-dev static-site-generator-webpack-plugin@medialaan/static-site-generator-webpack-plugin#58524c0
```