### PR TITLE
Add support for Webpack 4 webhooks

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,8 +22,8 @@ function StaticSiteGeneratorWebpackPlugin(options) {
 StaticSiteGeneratorWebpackPlugin.prototype.apply = function(compiler) {
   var self = this;
 
-  compiler.plugin('this-compilation', function(compilation) {
-    compilation.plugin('optimize-assets', function(_, done) {
+  addThisCompilationHandler(compiler, function(compilation) {
+    addOptimizeAssetsHandler(compilation, function(_, done) {
       var renderPromises;
 
       var webpackStats = compilation.getStats();
@@ -226,6 +226,24 @@ function legacyArgsToOptions(entry, paths, locals, globals) {
     locals: locals,
     globals: globals
   };
+}
+
+function addThisCompilationHandler(compiler, callback) {
+  if(compiler.hooks) {
+    /* istanbul ignore next */
+    compiler.hooks.thisCompilation.tap('static-site-generator-webpack-plugin', callback);
+  } else {
+    compiler.plugin('this-compilation', callback);
+  }
+}
+
+function addOptimizeAssetsHandler(compilation, callback) {
+  if(compilation.hooks) {
+    /* istanbul ignore next */
+    compilation.hooks.optimizeAssets.tapAsync('static-site-generator-webpack-plugin',callback);
+  } else {
+    compilation.plugin('optimize-assets', callback);
+  }
 }
 
 module.exports = StaticSiteGeneratorWebpackPlugin;


### PR DESCRIPTION
Recreating https://github.com/markdalgleish/static-site-generator-webpack-plugin/pull/132 by @getElementsByName
- Added `/* istanbul ignore next */` lines to pass code coverage