### PR TITLE
Exclude query and hash from path when crawling links

### DIFF
--- a/index.js
+++ b/index.js
@@ -206,13 +206,12 @@ function relativePathsFromHtml(options) {
 
       var parsed = url.parse(href);
 
-      if (parsed.protocol || typeof parsed.path !== 'string') {
+      if (parsed.protocol || typeof parsed.pathname !== 'string') {
         return null;
       }
-
-      return parsed.path.indexOf('/') === 0 ?
-        parsed.path :
-        url.resolve(currentPath, parsed.path);
+      return parsed.pathname.indexOf('/') === 0 ?
+        parsed.pathname :
+        url.resolve(currentPath, parsed.pathname);
     })
     .filter(function(href) {
       return href != null;

--- a/test/__snapshots__/index.spec.js.snap
+++ b/test/__snapshots__/index.spec.js.snap
@@ -88,6 +88,32 @@ Object {
 }
 `;
 
+exports[`Success cases crawl-duplicates should generate the expected files 1`] = `
+Object {
+  "bar/index.html": "<h1>/bar</h1>
+
+<a href=\\"baz#oz\\">Crawl this</a>
+<a href=\\"baz\\">And this</a>
+",
+  "baz/index.html": "<h1>/baz</h1>
+
+<a href=\\"baz#oz\\">Crawl this</a>
+<a href=\\"baz\\">And this</a>
+",
+  "foo/index.html": "<h1>/foo</h1>
+
+<a href=\\"baz?m=1\\">Crawl this</a>
+<a href=\\"baz\\">And this</a>
+",
+  "index.html": "<h1>/</h1>
+
+<a href=\\"foo\\">Crawl this</a>
+<a href=\\"bar\\">And this</a>
+",
+  "index.js": "CONTENTS IGNORED IN SNAPSHOT TEST",
+}
+`;
+
 exports[`Success cases crawl-ignore should generate the expected files 1`] = `
 Object {
   "index.html": "<p>Don't crawl these:</p>

--- a/test/success-cases/crawl-duplicates/index.js
+++ b/test/success-cases/crawl-duplicates/index.js
@@ -1,0 +1,41 @@
+module.exports = function(locals) {
+  try {
+  switch (locals.path) {
+    case '/': {
+      return locals.template({
+        path: locals.path,
+        link1: 'foo',
+        link2: 'bar'
+      });
+    }
+    case '/foo': {
+      return locals.template({
+        path: locals.path,
+        link1: 'baz?m=1',
+        link2: 'baz'
+      });
+    }
+    case '/bar': {
+      return locals.template({
+        path: locals.path,
+        link1: 'baz#oz',
+        link2: 'baz'
+      });
+    }
+    case '/baz?m=1':
+    case '/baz#oz':
+    case '/baz': {
+      return locals.template({
+        path: locals.path,
+        link1: 'baz#oz',
+        link2: 'baz'
+      });
+    }
+    default: {
+      return '404 ' + locals.path;
+    }
+  }}
+  catch( error) {
+    return '500'
+  }
+};

--- a/test/success-cases/crawl-duplicates/template.ejs
+++ b/test/success-cases/crawl-duplicates/template.ejs
@@ -1,0 +1,4 @@
+<h1><%= path %></h1>
+
+<a href="<%= link1 %>">Crawl this</a>
+<a href="<%= link2 %>">And this</a>

--- a/test/success-cases/crawl-duplicates/webpack.config.js
+++ b/test/success-cases/crawl-duplicates/webpack.config.js
@@ -1,0 +1,25 @@
+var StaticSiteGeneratorPlugin = require('../../../');
+var ejs = require('ejs');
+var fs = require('fs');
+
+var templateSource = fs.readFileSync(__dirname + '/template.ejs', 'utf-8');
+var template = ejs.compile(templateSource);
+
+module.exports = {
+  entry: __dirname + '/index.js',
+
+  output: {
+    filename: 'index.js',
+    path: __dirname + '/actual-output',
+    libraryTarget: 'umd'
+  },
+
+  plugins: [
+    new StaticSiteGeneratorPlugin({
+      crawl: true,
+      locals: {
+        template: template
+      }
+    })
+  ]
+};


### PR DESCRIPTION
Re-creates https://github.com/markdalgleish/static-site-generator-webpack-plugin/pull/114 due to branch changes

When crawling links to render a link such as `/foo?bar` will attempt to create file `/foo?bar.html` this may not be ideal. This change has the link crawl behaviour ignore query parameters and hashes by using the url's `pathname` instead of `path`.

closes https://github.com/markdalgleish/static-site-generator-webpack-plugin/issues/113
closes https://github.com/markdalgleish/static-site-generator-webpack-plugin/issues/109